### PR TITLE
Add disk check test

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -5,6 +5,10 @@
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.5.0">>},0},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.6.0">>},1},
+ {<<"genlib">>,
+  {git,"https://github.com/rbkmoney/genlib.git",
+       {ref,"901f5d7232e21cddc80c2864bf0c918e862b861a"}},
+  0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.8.0">>},0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.6.2">>},1}]}.
 [

--- a/src/erl_health.erl
+++ b/src/erl_health.erl
@@ -147,10 +147,14 @@ memory(Limit) ->
 -spec cg_memory(number()) ->
     result().
 cg_memory(Limit) ->
-    RSS = genlib:define(cg_mem_sup:rss(), 0),
-    Total = genlib:define(cg_mem_sup:limit(), 1),
-    Details = genlib_map:compact(#{rss => RSS, total => Total}),
-    limit(RSS * 100 div Total, Limit, Details).
+    cg_memory(cg_mem_sup:rss(), cg_mem_sup:limit(), Limit).
+
+cg_memory(RSS, Total, Limit) when is_integer(RSS), is_integer(Total), Total > 0 ->
+    Details = #{rss => RSS, total => Total},
+    limit(RSS * 100 div Total, Limit, Details);
+cg_memory(_, _, Limit) ->
+    % we don't know (probably yet) cgroup memory metrics
+    {passing, #{value => unknown, limit => Limit}}.
 
 %% disk limit
 %% 3-th element from disksup:get_disk_data()

--- a/src/erl_health.erl
+++ b/src/erl_health.erl
@@ -147,9 +147,9 @@ memory(Limit) ->
 -spec cg_memory(number()) ->
     result().
 cg_memory(Limit) ->
-    RSS = cg_mem_sup:rss(),
-    Total = cg_mem_sup:limit(),
-    Details = #{rss => RSS, total => Total},
+    RSS = genlib:define(cg_mem_sup:rss(), 0),
+    Total = genlib:define(cg_mem_sup:limit(), 1),
+    Details = genlib_map:compact(#{rss => RSS, total => Total}),
     limit(RSS * 100 div Total, Limit, Details).
 
 %% disk limit

--- a/test/erl_health_tests.erl
+++ b/test/erl_health_tests.erl
@@ -49,6 +49,18 @@ memory_test_() ->
         )
     ].
 
+-spec disk_test_() ->
+    [testcase()].
+disk_test_() ->
+    [
+        ?_assertMatch(
+            {passing, #{dsk := #{path := <<"/">>, limit := 100}}},
+            erl_health:check(#{
+                dsk => {erl_health, disk, ["/", 100]}
+            })
+        )
+    ].
+
 -spec compose_test_() ->
     [testcase()].
 compose_test_() ->


### PR DESCRIPTION
As observed in:
```
Healthcheck memory failed: error:badarith in call to erlang:*(undefined,100)
	called from erl_health:cg_memory/1 at <...>/_build/default/lib/erl_health/src/erl_health.erl:153
	called from erl_health:run_checker/2 at <...>/_build/default/lib/erl_health/src/erl_health.erl:69
	called from erl_health:-check/1-fun-0-/3 at <...>/_build/default/lib/erl_health/src/erl_health.erl:62
	called from maps:fold_1/3 at maps.erl:257
	called from erl_health_handle:init/2 at <...>/_build/default/lib/erl_health/src/erl_health_handle.erl:25
	called from cowboy_handler:execute/2 at <...>/_build/default/lib/cowboy/src/cowboy_handler.erl:41
	...
```